### PR TITLE
Support Runtime on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The default installation dependencies, as defined in the `pyproject.toml`, are s
 > Users have run this codebase with Python 3.9,3.10 and cuda_12, cuda-11.8
 
 ```
-> pip install .
+> pip install -e .
 ```
 
 Developers should set up `pre-commit` as well with `pre-commit install`.

--- a/ml_mdm/clis/generate_sample.py
+++ b/ml_mdm/clis/generate_sample.py
@@ -20,7 +20,13 @@ from ml_mdm import helpers, reader
 from ml_mdm.config import get_arguments, get_model, get_pipeline
 from ml_mdm.language_models import factory
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device(
+    "cuda"
+    if torch.cuda.is_available()
+    else "mps"
+    if torch.backends.mps.is_available()
+    else "cpu"
+)
 
 # Note that it is called add_arguments, not add_argument.
 logging.basicConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "imageio[ffmpeg]",
     "matplotlib",
     "mlx-data",
-    "numpy",
+    "numpy<2",
     "pytorch-model-summary",
     "rotary-embedding-torch",
     "simple-parsing==0.1.5",


### PR DESCRIPTION
**Major improvement** 
Support Web Demo on Apple Silicon (tested on M3 Max), and boosted inference speed 28 times, from 38.5s per iteration to 1.4s per iteration 

**Other Changes**
1. Running on Mac with default numpy version (2.0.1) led to the following warning
```
[2024-08-11 15:21:11,167] torch.distributed.elastic.multiprocessing.redirects: [WARNING] NOTE: Redirects are currently not supported in Windows or MacOs.

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.1 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```
and error 
```
  File "ml-mdm/ml_mdm/language_models/factory.py", line 68, in forward
    torch.from_numpy(sample["tokens"]).to(self.device).type(torch.long)
RuntimeError: Numpy is not available
```
therefore, adding version limit `numpy<2`
2. In README, use editable install to install the local version of codes. Had the following error, when not installing with the flag in condo environment
```
../../../miniconda3/envs/ml-mdm/lib/python3.9/site-packages/ml_mdm/reader.py:13: in <module>
    from ml_mdm.language_models.tokenizer import Tokenizer
E   ModuleNotFoundError: No module named 'ml_mdm.language_models
```