### PR TITLE
Find packages on setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["ml_mdm*"]
+exclude = ["tests*", "*clis*"]
 
 [project]
 name = "ml_mdm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 requires = ["setuptools>=70.0.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["ml_mdm"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ml_mdm*"]
 
 [project]
 name = "ml_mdm"


### PR DESCRIPTION
So that `pip install .` works (and potentially, a PyPi distribution could be made).

To reproduce, before this PR the following failed when using `pip install .` (but worked with `pip install -e .`):

```bash
rm -rf build
python -c "from ml_mdm import reader"
```

(Observe that `build/lib/ml_mdm` does not contain any subfolders without this PR).
