### PR TITLE
Fix typo in cc12m_256x256.yaml

### DIFF
--- a/configs/models/cc12m_256x256.yaml
+++ b/configs/models/cc12m_256x256.yaml
@@ -4,7 +4,7 @@ dataset_config: configs/datasets/cc12m.yaml
 min_examples: 10000
 sample-dir: /mnt/data/samples
 # batch-size: 32
-sample_image-size: 256
+sample_image_size: 256
 test_file_list: validation.tsv
 #reader-config-file: configs/datasets/reader_config_eval.yaml
 # shared_arguments


### PR DESCRIPTION
This prevents the 256 model from running, as `sample_image_size` is parsed as `-1`.