### PR TITLE
Update `cc12m_256x256.yaml` with diffusion_config addition and use `null` as a correct version of `None`

### DIFF
--- a/configs/models/cc12m_1024x1024.yaml
+++ b/configs/models/cc12m_1024x1024.yaml
@@ -102,6 +102,21 @@ unet_config:
   temporal_mode: false
   temporal_positional_encoding: false
   temporal_spatial_ds: false
+diffusion_config:
+  sampler_config:
+    num_diffusion_steps: 1000
+    reproject_signal: False
+    schedule_type: DEEPFLOYD
+    prediction_type: V_PREDICTION
+    loss_target_type: DDPM
+    beta_start: 0.0001
+    beta_end: 0.02
+    threshold_function: CLIP
+    rescale_schedule: 1.0
+    schedule_shifted: True
+  model_output_scale: 0.0
+  use_vdm_loss_weights: False
+  no_use_residual: true
 
 # import defaults
 # reader-config-file: configs/datasets/reader_config.yaml

--- a/configs/models/cc12m_256x256.yaml
+++ b/configs/models/cc12m_256x256.yaml
@@ -36,7 +36,7 @@ unet_config:
   conditioning_feature_dim: -1
   conditioning_feature_proj_dim: -1
   freeze_inner_unet: false
-  initialize_inner_with_pretrained: None
+  initialize_inner_with_pretrained: null
   inner_config:
     attention_levels: [1, 2]
     conditioning_feature_dim: -1
@@ -76,6 +76,21 @@ unet_config:
   temporal_mode: false
   temporal_positional_encoding: false
   temporal_spatial_ds: false
+diffusion_config:
+  sampler_config:
+    num_diffusion_steps: 1000
+    reproject_signal: False
+    schedule_type: DEEPFLOYD
+    prediction_type: V_PREDICTION
+    loss_target_type: DDPM
+    beta_start: 0.0001
+    beta_end: 0.02
+    threshold_function: CLIP
+    rescale_schedule: 1.0
+    schedule_shifted: True
+  model_output_scale: 0.0
+  use_vdm_loss_weights: False
+  no_use_residual: true
 
 reader_config:
   image_size: 256


### PR DESCRIPTION
Proposes to fix #10 

1. This pull request updates the `cc12m_256x256.yaml` and `cc12m_1024x1024.yaml` files by adding a `diffusion_config` section because samplers are created with `diffusion_config.sampler_config`:
https://github.com/apple/ml-mdm/blob/36959179b5c103cfe014c2ddaef91c6a24feefbe/ml_mdm/diffusion.py#L94
https://github.com/apple/ml-mdm/blob/36959179b5c103cfe014c2ddaef91c6a24feefbe/ml_mdm/diffusion.py#L287

2. Also, `diffusion_config.no_use_residual` is needed:
https://github.com/apple/ml-mdm/blob/36959179b5c103cfe014c2ddaef91c6a24feefbe/ml_mdm/diffusion.py#L262

3. `None` in the file is read by `'None'` -as a string.

@jlukecarlson