### PR TITLE
Refactor `samplers.py` to correctly handle scaling when `config.schedule_shifted` is `True`

### DIFF
--- a/ml_mdm/samplers.py
+++ b/ml_mdm/samplers.py
@@ -597,7 +597,7 @@ class NestedSampler(Sampler):
             x_t += [
                 super().get_xt(
                     self.get_image_rescaled(x, s)
-                    if not self._config.schedule_shifted
+                    if self._config.schedule_shifted
                     else x,
                     e,
                     gi,
@@ -611,7 +611,7 @@ class NestedSampler(Sampler):
             tgt += [
                 super().get_prediction_targets(
                     self.get_image_rescaled(x, s)
-                    if not self._config.schedule_shifted
+                    if self._config.schedule_shifted
                     else x,
                     e,
                     gi,
@@ -668,7 +668,7 @@ class NestedSampler(Sampler):
                         need_noise=time_step != 1,
                         ddim_eta=ddim_eta,
                         clip_fn=self.clip_sample,
-                        image_scale=s if not self._config.schedule_shifted else 1,
+                        image_scale=s if self._config.schedule_shifted else 1,
                     )
                     for x, p, g, g_last, s in zip(x_t, p_t, g_t, g_s, scales)
                 ]
@@ -693,7 +693,7 @@ class NestedSampler(Sampler):
     ):
         scales = [
             x_t[i].size(-1) / x_t[-1].size(-1)
-            if not self._config.schedule_shifted
+            if self._config.schedule_shifted
             else 1
             for i in range(len(x_t))
         ]


### PR DESCRIPTION
This pull request proposes a refactoring of the `samplers.py` file to ensure correct handling of scaling when the `config.schedule_shifted` flag is set to `True`. This change improves the behavior of the code, especially for higher resolutions.

Prompt = `a blue jay stops on the top of a helmet of Japanese samurai, background with sakura tree`
Guidance scale = `7.5`
Thresholding = `clip`
Number of steps = `250`
**Before 1024x1024**             |  **After 1024x1024**
:-------------------------:|:-------------------------:
| <img src="https://github.com/user-attachments/assets/8408fd08-785f-4b5e-8366-2f2f2b022d67" width="350" height="350" alt="before"> | <img src="https://github.com/user-attachments/assets/742568f2-1cb0-4a6c-ad05-8ed5a46edc36" width="350" height="350" alt="after"> |

@jlukecarlson