### PR TITLE
Issue 39 - Switch the default pytest call to run just CPU test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Developers should set up `pre-commit` as well with `pre-commit install`.
 ### Running Test Cases
 
 ```
-> pytest   # will run all test cases - including ones that require a gpu
-> pytest  -m "not gpu"  # run test cases that can work with just cpu
+> pytest   # run test cases that can work with just cpu
+> pytest  -m ''  # will run all test cases - including ones that require a gpu
+> pytest -m gpu # run only gpu test cases
 ```
 
 

--- a/ml_mdm/diffusion.py
+++ b/ml_mdm/diffusion.py
@@ -29,7 +29,8 @@ def sv(x, f):
 @dataclass
 class DiffusionConfig:
     sampler_config: samplers.SamplerConfig = field(
-        default=samplers.SamplerConfig(), metadata={"help": "Sampler configuration"}
+        default_factory=samplers.SamplerConfig,  # Changed from default=samplers.SamplerConfig(), 
+        metadata={"help": "Sampler configuration"}
     )
     model_output_scale: float = field(
         default=0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ known_numeric = ["torch", "torchvision", "numpy", "jax", "flax", "mlx"]
 
 
 [tool.pytest.ini_options]
-addopts = "--cov=ml_mdm"
+addopts = "--cov=ml_mdm -m 'not gpu'"
 markers = [
     "gpu" # tests that require a gpu
 ]


### PR DESCRIPTION
switches the default pytest call to run just CPU test cases and updates the readme with new instructions.  