### PR TITLE
Separate python dependencies into optional groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ In the `ml_mdm.models` submodule, we've open sourced our implementations of:
 > In essence, `simple_parsing` will convert all passed cli arguments and yaml files into clean configuration classes like `ml_mdm.reader.ReaderConfig`, `ml_mdm.diffusion.DiffusionConfig`.
 
 
+`ml_mdm.config` stores a global mapping of names to classes in `MODEL_REGISTRY`, `MODEL_CONFIG_REGISTRY`, `PIPELINE_REGISTRY`, and `PIPELINE_CONFIG_REGISTRY`.
+
+`MODEL_REGISTRY` and `PIPELINE_REGISTRY` store information as shown in the following example
+
+> *_CONFIG_REGISTRY[architecture name]["model"] = model name
+> *_CONFIG_REGISTRY[architecture name]["config"] = configuration class
+
+MODEL_CONFIG_REGISTRY and PIPELINE_CONFIG_REGISTRY stores information as shown in the following example: 
+> *_CONFIG_REGISTRY[architecture name]["model"] = model name
+> *_CONFIG_REGISTRY[architecture name]["config"] = configuration class
+
+
+architecture name and model name are passed into ml_mdm.config through the function parameter *names. where *names points to "architecture name", "model name"
+
 
 
 # Tutorials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ profile = "black"
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "NUMERIC", "FIRSTPARTY", "LOCALFOLDER"]
 known_numeric = ["torch", "torchvision", "numpy", "jax", "flax", "mlx"]
 
-
 [tool.pytest.ini_options]
 addopts = "--cov=ml_mdm -m 'not gpu'"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,33 +17,39 @@ description = "A python package to simplify the creation of text conditioned ima
 dependencies = [
     "dataclass-wizard",
     "einops",
-    "fastapi>=0.109.1", # Required due to CVE-2024-24762
-    "gradio>=4.14", # Required due to CVE-2023-6572
     "httpx==0.24.1",
-    "imageio[ffmpeg]",
-    "matplotlib",
     "mlx-data",
     "numpy<2",
-    "pytorch-model-summary",
-    "rotary-embedding-torch",
     "simple-parsing==0.1.5",
-    "tensorboardX==2.6.2.2",
-    "tensorboard==2.16.2",
-    "torchinfo",
-    "torchmetrics[image]",
     "torchvision",
     "transformers",
     "sentencepiece",
-    "boto3",
     "torch==2.2.2",
-    "pytest",
-    "pytest-cov",
-    "pre-commit"
 ]
 
 [project.optional-dependencies]
 data_prep = [
-    "img2dataset"
+    "img2dataset",
+    "boto3",
+]
+web_demo = [
+    "fastapi>=0.109.1", # Required due to CVE-2024-24762
+    "gradio>=4.14", # Required due to CVE-2023-6572
+    "matplotlib",
+    "imageio[ffmpeg]",
+]
+training = [
+    "tensorboard==2.16.2",
+    "tensorboardX==2.6.2.2",
+    "torchmetrics[image]",
+    "rotary-embedding-torch",
+    "pytorch-model-summary",
+    "torchinfo",
+]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pre-commit",
 ]
 
 [tool.isort]


### PR DESCRIPTION
Associated issue: https://github.com/apple/ml-mdm/issues/38.

@luke-carlson I tried my best to identify the purpose of each dependency. Still, I might have wrongly grouped some core dependencies as optional and/or vice-versa, which could lead to bugs. Please let me know if you believe I should make any changes to reflect the correct architecture.